### PR TITLE
#133002627 admin user should be able to cancel orders refactor

### DIFF
--- a/imports/plugins/core/checkout/client/templates/checkout/completed/completed.js
+++ b/imports/plugins/core/checkout/client/templates/checkout/completed/completed.js
@@ -29,8 +29,14 @@ Template.cartCompleted.helpers({
   orderStatus: function () {
     if (this.workflow.status === "new") {
       return i18next.t("cartCompleted.submitted");
+    } else if (this.workflow.status === "coreOrderWorkflow/cancel-request") {
+      return "being processed for cancelation";
+    } else if (this.workflow.status === "coreOrderWorkflow/processing") {
+      return "processing";
+    } else if (this.workflow.status === "coreOrderWorkflow/shipped") {
+      return "shipped";
     }
-    return this.workflow.status;
+    return "delivered";
   },
   userOrders: function () {
     if (Meteor.user()) {

--- a/imports/plugins/core/orders/client/templates/list/ordersList.html
+++ b/imports/plugins/core/orders/client/templates/list/ordersList.html
@@ -19,11 +19,12 @@
           </strong>
         </div>
         <div class="col-xs-6 col-sm-10">
-          {{#if orderStatus}}
+          <!-- {{#if orderStatus}}
               <span data-i18n="order.completed">Completed</span>
           {{else}}
               <span data-i18n="order.processing">Processing</span>
-          {{/if}}
+          {{/if}} -->
+          <span>{{orderStatus}}</span>
         </div>
       </div>
 

--- a/imports/plugins/core/orders/client/templates/list/ordersList.html
+++ b/imports/plugins/core/orders/client/templates/list/ordersList.html
@@ -19,11 +19,6 @@
           </strong>
         </div>
         <div class="col-xs-6 col-sm-10">
-          <!-- {{#if orderStatus}}
-              <span data-i18n="order.completed">Completed</span>
-          {{else}}
-              <span data-i18n="order.processing">Processing</span>
-          {{/if}} -->
           <span>{{orderStatus}}</span>
         </div>
       </div>

--- a/imports/plugins/core/orders/client/templates/list/ordersList.html
+++ b/imports/plugins/core/orders/client/templates/list/ordersList.html
@@ -79,6 +79,13 @@
         </div>
       </div>
 
+      {{#if showCanceled}}
+        <div class="row cancel-order">
+          <div class="col-xs-12">
+            {{>React CancelOrderButton}}
+          </div>
+        </div>
+      {{/if}}
       <div class="row order-group-title">
         <div class="col-xs-12">
           <strong>

--- a/imports/plugins/core/orders/client/templates/list/ordersList.js
+++ b/imports/plugins/core/orders/client/templates/list/ordersList.js
@@ -43,6 +43,13 @@ Template.dashboardOrdersList.helpers({
     const shop = Shops.findOne(this.shopId);
     return shop !== null ? shop.name : void 0;
   },
+  getClassName(orders) {
+    order = orders || Template.instance().data;
+    if (order.workflow.status === "coreOrderWorkflow/cancel-request") {
+      return true;
+    }
+    return false;
+  },
   // Create a helper to import in the FlatButton react component for
   // cancelOrder button
   CancelOrderButton() {
@@ -52,6 +59,7 @@ Template.dashboardOrdersList.helpers({
       kind: "flat",
       className: "btn-danger btn-sm",
       label: "Cancel order",
+      disabled: Template.dashboardOrdersList.__helpers.get("getClassName").call(this, order),
       onClick() {
         Alerts.alert({
           title: "Cancel order",

--- a/imports/plugins/core/orders/client/templates/list/ordersList.js
+++ b/imports/plugins/core/orders/client/templates/list/ordersList.js
@@ -8,9 +8,10 @@ import { Orders, Shops } from "/lib/collections";
  */
 Template.dashboardOrdersList.helpers({
   orderStatus() {
-    if (this.workflow.status === "coreOrderCompleted") {
-      return true;
-    }
+    // if (this.workflow.status === "coreOrderCompleted") {
+    //   return true;
+    // }
+    return this.workflow.status.split("/")[1];
   },
   orders(data) {
     if (data.hash.data) {

--- a/imports/plugins/core/orders/client/templates/list/ordersList.js
+++ b/imports/plugins/core/orders/client/templates/list/ordersList.js
@@ -2,16 +2,22 @@ import moment from "moment";
 import { Template } from "meteor/templating";
 import { Orders, Shops } from "/lib/collections";
 
+import FlatButton from "/imports/plugins/core/ui/client/components/button/flatButton"; // Import flatbutton react component
+
+
 /**
  * dashboardOrdersList helpers
  *
  */
 Template.dashboardOrdersList.helpers({
   orderStatus() {
-    // if (this.workflow.status === "coreOrderCompleted") {
-    //   return true;
-    // }
     return this.workflow.status.split("/")[1];
+  },
+  showCanceled() {
+    if (this.workflow.status === "coreOrderWorkflow/canceled" || this.workflow.status === "coreOrderWorkflow/completed") {
+      return false;
+    }
+    return true;
   },
   orders(data) {
     if (data.hash.data) {
@@ -33,5 +39,34 @@ Template.dashboardOrdersList.helpers({
   shopName() {
     const shop = Shops.findOne(this.shopId);
     return shop !== null ? shop.name : void 0;
+  },
+  // Create a helper to import in the FlatButton react component for
+  // cancelOrder button
+  CancelOrderButton() {
+    const order = this;
+    return  {
+      component: FlatButton,
+      kind: "flat",
+      className: "btn-danger btn-sm",
+      label: "Cancel order",
+      onClick() {
+        Alerts.alert({
+          title: "Cancel order",
+          text: `Are you sure you want to cancel this order,
+          your shipping charge would not be refunded if your
+          order has been shipped`,
+          showCancelButton: true,
+          confirmButtonText: "Cancel Order"
+        }, (isConfirm) => {
+          if (isConfirm) {
+            Meteor.call("orders/customerCancelOrder", order._id, function (error) {
+              if (error) {
+                console.log("error", error);
+              }
+            });
+          }
+        });
+      }
+    };
   }
 });

--- a/imports/plugins/core/orders/client/templates/list/ordersList.js
+++ b/imports/plugins/core/orders/client/templates/list/ordersList.js
@@ -11,8 +11,8 @@ import FlatButton from "/imports/plugins/core/ui/client/components/button/flatBu
  */
 Template.dashboardOrdersList.helpers({
   orderStatus() {
-    if (this.workflow.status === "coreOrderWorkflow/cancel-request") {
-      return "Processing Cancel request";
+    if (this.workflow.status === "new") {
+      return "submitted";
     }
     return this.workflow.status.split("/")[1];
   },

--- a/imports/plugins/core/orders/client/templates/list/ordersList.js
+++ b/imports/plugins/core/orders/client/templates/list/ordersList.js
@@ -11,6 +11,9 @@ import FlatButton from "/imports/plugins/core/ui/client/components/button/flatBu
  */
 Template.dashboardOrdersList.helpers({
   orderStatus() {
+    if (this.workflow.status === "coreOrderWorkflow/cancel-request") {
+      return "Processing Cancel request";
+    }
     return this.workflow.status.split("/")[1];
   },
   showCanceled() {

--- a/imports/plugins/core/orders/client/templates/orders.html
+++ b/imports/plugins/core/orders/client/templates/orders.html
@@ -72,7 +72,7 @@
   <div class="col-xs-8">
     <div data-i18n="orderDetail.created">Created {{orderAge}} {{dateFormat createdAt format="MMM D, YYYY hh:mm:ss A"}}</div>
     <p>
-      Tracking: <a href="#">{{shipmentTracking}}</a> - 
+      Tracking: <a href="#">{{shipmentTracking}}</a> -
       <span class="badge badge-{{shipmentStatus.status}}">{{shipmentStatus.label}}</span>
     </p>
   </div>

--- a/imports/plugins/core/orders/client/templates/orders.js
+++ b/imports/plugins/core/orders/client/templates/orders.js
@@ -11,6 +11,9 @@ const orderFilters = [{
   name: "processing",
   label: "Processing"
 }, {
+  name: "shipped",
+  label: "Shipped"
+}, {
   name: "completed",
   label: "Completed"
 }, {
@@ -40,7 +43,8 @@ const OrderHelper =  {
       // Orders that have been shipped, based on if the items have been shipped
       case "shipped":
         query = {
-          "items.workflow.status": "coreOrderItemWorkflow/shipped"
+          // "items.workflow.status": "coreOrderItemWorkflow/shipped"
+          "workflow.status": "coreOrderWorkflow/shipped"
         };
         break;
 
@@ -314,7 +318,18 @@ Template.orderStatusDetail.helpers({
         if (fullItem._id === shipmentItem._id) {
           if (fullItem.workflow) {
             if (_.isArray(fullItem.workflow.workflow)) {
-              return _.includes(fullItem.workflow.workflow, "coreOrderItemWorkflow/completed");
+              return fullItem.workflow.status === "coreOrderItemWorkflow/shipped";
+            }
+          }
+        }
+      }
+    });
+    const completed = _.every(shipment.items, (shipmentItem) => {
+      for (const fullItem of self.items) {
+        if (fullItem._id === shipmentItem._id) {
+          if (fullItem.workflow) {
+            if (_.isArray(fullItem.workflow.workflow)) {
+              return fullItem.workflow.status === "coreOrderItemWorkflow/completed";
             }
           }
         }
@@ -333,7 +348,7 @@ Template.orderStatusDetail.helpers({
     if (shipped) {
       return {
         shipped: true,
-        status: "success",
+        status: "info",
         label: i18next.t("orderShipping.shipped")
       };
     } else if (canceled) {
@@ -342,11 +357,17 @@ Template.orderStatusDetail.helpers({
         status: "danger",
         label: i18next.t("orderShipping.canceled")
       };
+    } else if (completed) {
+      return {
+        shipped: true,
+        status: "success",
+        label: "Delivered"
+      };
     }
 
     return {
       shipped: false,
-      status: "info",
+      status: "warning",
       label: i18next.t("orderShipping.notShipped")
     };
   }

--- a/imports/plugins/core/orders/client/templates/orders.js
+++ b/imports/plugins/core/orders/client/templates/orders.js
@@ -11,6 +11,9 @@ const orderFilters = [{
   name: "processing",
   label: "Processing"
 }, {
+  name: "cancel-request",
+  label: "Cancel request"
+}, {
   name: "shipped",
   label: "Shipped"
 }, {
@@ -63,6 +66,12 @@ const OrderHelper =  {
         query = {
           "billing.paymentMethod.status": "completed",
           "shipping.shipped": false
+        };
+        break;
+
+      case "cancel-request":
+        query = {
+          "workflow.status": "coreOrderWorkflow/cancel-request"
         };
         break;
 

--- a/imports/plugins/core/orders/client/templates/workflow/shippingSummary.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingSummary.js
@@ -84,7 +84,27 @@ Template.coreOrderShippingSummary.helpers({
         if (fullItem._id === shipmentItem._id) {
           if (fullItem.workflow) {
             if (_.isArray(fullItem.workflow.workflow)) {
-              return _.includes(fullItem.workflow.workflow, "coreOrderItemWorkflow/completed");
+              return fullItem.workflow.status === "coreOrderItemWorkflow/shipped";
+            }
+          }
+        }
+      }
+    });
+    const canceled = _.every(shipment.items, (shipmentItem) => {
+      for (const fullItem of order.items) {
+        if (fullItem._id === shipmentItem._id) {
+          if (fullItem.workflow) {
+            return fullItem.workflow.status === "coreOrderItemWorkflow/canceled";
+          }
+        }
+      }
+    });
+    const completed = _.every(shipment.items, (shipmentItem) => {
+      for (const fullItem of order.items) {
+        if (fullItem._id === shipmentItem._id) {
+          if (fullItem.workflow) {
+            if (_.isArray(fullItem.workflow.workflow)) {
+              return fullItem.workflow.status === "coreOrderItemWorkflow/completed";
             }
           }
         }
@@ -94,14 +114,26 @@ Template.coreOrderShippingSummary.helpers({
     if (shipped) {
       return {
         shipped: true,
-        status: "success",
+        status: "info",
         label: i18next.t("orderShipping.shipped")
+      };
+    } else if (canceled) {
+      return {
+        shipped: false,
+        status: "danger",
+        label: i18next.t("orderShipping.canceled")
+      };
+    } else if (completed) {
+      return {
+        shipped: true,
+        status: "success",
+        label: "Delivered"
       };
     }
 
     return {
       shipped: false,
-      status: "info",
+      status: "warning",
       label: i18next.t("orderShipping.notShipped")
     };
   }

--- a/imports/plugins/core/orders/client/templates/workflow/shippingTracking.html
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingTracking.html
@@ -13,26 +13,32 @@
       <button class="btn btn-link" data-event-action="editTracking">{{shipment.tracking}}</button>
      {{/if}}
 
-    {{#if isCompleted}}
-      {{i18n "orderShipping.itemsHaveBeenShipped" "Items have been shipped"}}
-      <button class="btn btn-default" data-event-action="resendNotification" data-i18n="orderShipping.resendNotification">Resend Shipment Notification</button>
-    {{else}}
-
-    <hr>
-      {{#if shipmentReady}}
-        <p data-i18n="orderShipping.shippingNotifyCustomer">Notify the customer that their items will be shipping soon.</p>
-        <button class="btn btn-success btn-block" data-event-action="shipmentShipped" data-i18n="orderShipping.shipped">Shipped</button>
+    {{#unless isCompleted}}
+      {{#if isShipped}}
+        {{i18n "orderShipping.itemsHaveBeenShipped" "Items have been shipped"}}
+        <button class="btn btn-default" data-event-action="resendNotification" data-i18n="orderShipping.resendNotification">Resend Shipment Notification</button>
       {{else}}
-        <button
-          class="btn btn-default btn-block"
-          type="button"
-          data-i18n="orderShipping.shipmentPacked"
-          data-event-action="shipmentPacked">All Items Packed, Ready to Ship</button>
-          <div style="padding: 10px 0">
-            {{> React CancelOrderButton}}
-          </div>
+
+      <hr>
+        {{#if shipmentReady}}
+          <p data-i18n="orderShipping.shippingNotifyCustomer">Notify the customer that their items will be shipping soon.</p>
+          <button class="btn btn-success btn-block" data-event-action="shipmentShipped" data-i18n="orderShipping.shipped">Shipped</button>
+        {{else}}
+          <button
+            class="btn btn-default btn-block"
+            type="button"
+            data-i18n="orderShipping.shipmentPacked"
+            data-event-action="shipmentPacked">All Items Packed, Ready to Ship</button>
+        {{/if}}
       {{/if}}
-    {{/if}}
+    {{/unless}}
     <br/>
+    {{#unless isCompleted}}
+      <div class="cancel-panel">
+        <div style="padding: 10px 0">
+          {{> React CancelOrderButton}}
+        </div>
+      </div>
+    {{/unless}}
 {{/unless}}
 </template>

--- a/imports/plugins/core/orders/client/templates/workflow/shippingTracking.html
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingTracking.html
@@ -34,6 +34,13 @@
     {{/unless}}
     <br/>
     {{#unless isCompleted}}
+      {{#if isShipped}}
+        <div class="complete-panel">
+          <div style="padding: 10px 0">
+            {{> React CompleteOrderButton}}
+          </div>
+        </div>
+      {{/if}}
       <div class="cancel-panel">
         <div style="padding: 10px 0">
           {{> React CancelOrderButton}}

--- a/imports/plugins/core/orders/client/templates/workflow/shippingTracking.html
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingTracking.html
@@ -42,15 +42,21 @@
         </div>
       {{/if}}
       <div class="row cancel-panel">
-        <div class="col-xs-6 col-sm12">
+        <div class="col-xs-12 col-sm-6">
           <select id="cancelation-reason" name="cancelation-reason" class="form-control">
             <option value="failed-delivery" selected>Failed delivery</option>
             <option value="wrong-item">Wrong Item</option>
             <option value="damaged">Damaged in transit</option>
             <option value="out-of-stock">Item out of stock</option>
+            <option value="others">Other reasons</option>
           </select>
         </div>
-        <div class="col-xs-6 col-sm12">
+        <div class="col-xs-12 col-sm-6">
+          <input type="text" name="other-reasons" class="form-control other-reasons" placeholder="Other Reasons" />
+        </div>
+      </div>
+      <div class="row" style="padding:5px 0;">
+        <div class="col-xs-12 col-sm-6">
           {{> React CancelOrderButton}}
         </div>
       </div>

--- a/imports/plugins/core/orders/client/templates/workflow/shippingTracking.html
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingTracking.html
@@ -41,8 +41,16 @@
           </div>
         </div>
       {{/if}}
-      <div class="cancel-panel">
-        <div style="padding: 10px 0">
+      <div class="row cancel-panel">
+        <div class="col-xs-6 col-sm12">
+          <select id="cancelation-reason" name="cancelation-reason" class="form-control">
+            <option value="failed-delivery" selected>Failed delivery</option>
+            <option value="wrong-item">Wrong Item</option>
+            <option value="damaged">Damaged in transit</option>
+            <option value="out-of-stock">Item out of stock</option>
+          </select>
+        </div>
+        <div class="col-xs-6 col-sm12">
           {{> React CancelOrderButton}}
         </div>
       </div>

--- a/imports/plugins/core/orders/client/templates/workflow/shippingTracking.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingTracking.js
@@ -91,7 +91,6 @@ Template.coreOrderShippingTracking.helpers({
     });
     return shippedItems;
   },
-
   isCompleted() {
     const currentData = Template.currentData();
     const order = Template.instance().order;
@@ -108,7 +107,6 @@ Template.coreOrderShippingTracking.helpers({
 
     return completedItems;
   },
-
   editTracking() {
     const template = Template.instance();
     if (!template.order.shipping[0].tracking || template.showTrackingEditForm.get()) {
@@ -146,7 +144,8 @@ Template.coreOrderShippingTracking.helpers({
       className: "btn-danger btn-block",
       label: "Cancel order",
       onClick() {
-        Meteor.call("orders/cancelOrder", order._id, function (error) {
+        const reason = document.querySelector("#cancelation-reason").value;
+        Meteor.call("orders/cancelOrder", order._id, reason, function (error) {
           if (error) {
             console.log("error", error);
           }

--- a/imports/plugins/core/orders/client/templates/workflow/shippingTracking.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingTracking.js
@@ -136,17 +136,36 @@ Template.coreOrderShippingTracking.helpers({
     return (order.workflow.status === "coreOrderWorkflow/canceled");
   },
 
-  // Create a helper to import in the FlatButton react component
+  // Create a helper to import in the FlatButton react component for
+  // cancelOrder button
   CancelOrderButton() {
     const order = Template.instance().order;
     return  {
       component: FlatButton,
-      icon: "fa fa-times",
       kind: "flat",
       className: "btn-danger btn-block",
       label: "Cancel order",
       onClick() {
-        Meteor.call("orders/cancelOrder", order._id, function(error, result){
+        Meteor.call("orders/cancelOrder", order._id, function (error) {
+          if (error) {
+            console.log("error", error);
+          }
+        });
+      }
+    };
+  },
+
+  // Create a helper to import in the FlatButton react component for
+  // complete order button
+  CompleteOrderButton() {
+    const order = Template.instance().order;
+    return  {
+      component: FlatButton,
+      kind: "flat",
+      className: "btn-success btn-block",
+      label: "Complete order",
+      onClick() {
+        Meteor.call("orders/orderCompleted", order, function (error) {
           if (error) {
             console.log("error", error);
           }

--- a/imports/plugins/core/orders/client/templates/workflow/shippingTracking.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingTracking.js
@@ -144,7 +144,11 @@ Template.coreOrderShippingTracking.helpers({
       className: "btn-danger btn-block",
       label: "Cancel order",
       onClick() {
-        const reason = document.querySelector("#cancelation-reason").value;
+        let reason = document.querySelector("#cancelation-reason").value;
+
+        if (reason === "others") {
+          reason = document.querySelector(".other-reasons").value;
+        }
         Meteor.call("orders/cancelOrder", order._id, reason, function (error) {
           if (error) {
             console.log("error", error);

--- a/imports/plugins/core/orders/client/templates/workflow/shippingTracking.js
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingTracking.js
@@ -48,7 +48,7 @@ Template.coreOrderShippingTracking.events({
     });
   },
 
-  "click [data-event-action=shipmentPacked]": () => {
+  "click [data-event-action=shipmentPacked]": () => { // TODO: look into this
     const template = Template.instance();
 
     Meteor.call("orders/shipmentPacked", template.order, template.order.shipping[0], true);
@@ -87,10 +87,8 @@ Template.coreOrderShippingTracking.helpers({
           return true;
         }
       });
-
-      return _.includes(fullItem.workflow.workflow, "coreOrderItemWorkflow/shipped");
+      return fullItem.workflow.status === "coreOrderItemWorkflow/shipped";
     });
-
     return shippedItems;
   },
 
@@ -105,7 +103,7 @@ Template.coreOrderShippingTracking.helpers({
         }
       });
 
-      return _.includes(fullItem.workflow.workflow, "coreOrderItemWorkflow/completed");
+      return fullItem.workflow.status === "coreOrderItemWorkflow/completed";
     });
 
     return completedItems;

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -256,7 +256,6 @@ Meteor.methods({
 
     return {
       workflowResult: workflowResult,
-      // completedItems: completedItemsResult,
       shippedOrder: shippedOrderResult
     };
   },

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -1033,53 +1033,14 @@ Meteor.methods({
   "orders/customerCancelOrder": function (orderId) {
     check(orderId, String);
 
-    if (!Reaction.hasPermission("orders")) {
-      throw new Meteor.Error(403, "Access Denied");
-    }
+    Orders.update({
+      _id: orderId
+    }, {
+      $set: {
+        "workflow.status": "coreOrderWorkflow/cancel-request"
+      }
+    });
 
-    // order and billing information
-    const order = Orders.findOne(orderId);
-    const orderStatus = order.workflow.status;
-    const paymentMethod = order.billing[0].paymentMethod;
-    const paymentStatus = paymentMethod.status;
-    const amount = paymentMethod.amount;
-    const shipment = order.shipping[0];
-    const shipmentAmount = order.billing[0].invoice.shipping;
-    let amendedAmount = amount;
-
-    if (orderStatus === "coreOrderWorkflow/shipped") {
-      amendedAmount = amount - shipmentAmount;
-    }
-    // if payment has been captured
-    if (paymentStatus === "completed") {
-      // Refund money
-      Meteor.call("orders/refunds/create", orderId, paymentMethod, amendedAmount, (error) => {
-        if (error) {
-          Alerts.alert(error.reason);
-        } else {
-          // send an email to the user
-          Meteor.call("orders/sendCancelNotification", order, (err) => {
-            if (err) {
-              Logger.error(error, "orders/orderCanceled: Failed to send notification");
-            }
-          });
-        }
-      });
-    } else {
-      // send an email to the user
-      Meteor.call("orders/sendCancelNotification", order, (err) => {
-        if (err) {
-          Logger.error(error, "orders/orderCanceled: Failed to send notification");
-        }
-      });
-    }
-
-    // change the shipping status to canceled
-    Meteor.call("orders/shipmentCanceled", order, shipment);
-    // Change status of the order to canceled
-    completedOrderResult = Meteor.call("workflow/pushOrderWorkflow", "coreOrderWorkflow", "canceled", order);
-
-    // TODO: Restock the inventory
 
     return null;
   }

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -229,8 +229,8 @@ Meteor.methods({
 
     this.unblock();
 
-    let completedItemsResult;
-    let completedOrderResult;
+    // let completedItemsResult;
+    let shippedOrderResult;
 
     const itemIds = shipment.items.map((item) => {
       return item._id;
@@ -240,13 +240,8 @@ Meteor.methods({
     const workflowResult = Meteor.call("workflow/pushItemWorkflow", "coreOrderItemWorkflow/shipped", order, itemIds);
 
     if (workflowResult === 1) {
-      // Move to completed status for items
-      completedItemsResult = Meteor.call("workflow/pushItemWorkflow", "coreOrderItemWorkflow/completed", order, itemIds);
-
-      if (completedItemsResult === 1) {
-        // Then try to mark order as completed.
-        completedOrderResult = Meteor.call("workflow/pushOrderWorkflow", "coreOrderWorkflow", "completed", order);
-      }
+      // Mark order as shipped.
+      shippedOrderResult = Meteor.call("workflow/pushOrderWorkflow", "coreOrderWorkflow", "shipped", order);
     }
 
     if (order.email) {
@@ -261,8 +256,8 @@ Meteor.methods({
 
     return {
       workflowResult: workflowResult,
-      completedItems: completedItemsResult,
-      completedOrder: completedOrderResult
+      // completedItems: completedItemsResult,
+      shippedOrder: shippedOrderResult
     };
   },
 
@@ -541,6 +536,7 @@ Meteor.methods({
     return true;
   },
 
+  // mark orders completed
   /**
    * orders/orderCompleted
    *
@@ -557,7 +553,13 @@ Meteor.methods({
 
     this.unblock();
 
-    Meteor.call("workflow/pushOrderWorkflow", "coreOrderWorkflow", "coreOrderCompleted", order._id);
+    // Move to completed status for items
+    completedItemsResult = Meteor.call("workflow/pushItemWorkflow", "coreOrderItemWorkflow/completed", order, itemIds);
+
+    if (completedItemsResult === 1) {
+      // Then try to mark order as completed.
+      completedOrderResult = Meteor.call("workflow/pushOrderWorkflow", "coreOrderWorkflow", "completed", order);
+    }
 
     return this.orderCompleted(order);
   },

--- a/server/methods/core/orders.js
+++ b/server/methods/core/orders.js
@@ -536,7 +536,7 @@ Meteor.methods({
     return true;
   },
 
-  // mark orders completed
+  // mark orders completed might not be needed
   /**
    * orders/orderCompleted
    *
@@ -552,6 +552,10 @@ Meteor.methods({
     }
 
     this.unblock();
+    const shipment = order.shipping[0];
+    const itemIds = shipment.items.map((item) => {
+      return item._id;
+    });
 
     // Move to completed status for items
     completedItemsResult = Meteor.call("workflow/pushItemWorkflow", "coreOrderItemWorkflow/completed", order, itemIds);
@@ -560,8 +564,8 @@ Meteor.methods({
       // Then try to mark order as completed.
       completedOrderResult = Meteor.call("workflow/pushOrderWorkflow", "coreOrderWorkflow", "completed", order);
     }
-
-    return this.orderCompleted(order);
+    // TODO: send an email that the order has been delivered
+    // return this.orderCompleted(order);
   },
 
   /**


### PR DESCRIPTION
### What does this PR do?
It builds on PR #1 and adds in `shipping` into the workflow of `Orders` and `Items in Orders`. It adds in functionality to cancel an order before the order has been completed (delivered) for both the administrative user (Seller) and the buyer. 

### Description of Task to be completed?
* Add a React Js button component to the order list template for the buyer.
* Add shipping status as part of the order workflow.
* Add shipping as part of the order categories in the admin order view

### How should this be manually tested?
Login as a buyer and make an order. Go to the user profile page to view the orders the user has made ,the cancel order button should appear on orders that haven't been completed (delivered) or canceled.

### What are the relevant pivotal tracker stories?
#133002627 Admin user should be able to cancel orders

