### PR TITLE
#134137969 fixes add address error

### DIFF
--- a/lib/collections/schemas/accounts.js
+++ b/lib/collections/schemas/accounts.js
@@ -116,12 +116,12 @@ export const Accounts = new SimpleSchema({
   },
   hasTakenTour: {
     type: Boolean,
-    optional: false,
+    optional: true,
     defaultValue: false
   },
   hasTakenAdminTour: {
     type: Boolean,
-    optional: false,
+    optional: true,
     defaultValue: false
   }
 });

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "i18next-browser-languagedetector": "^1.0.1",
     "i18next-localstorage-cache": "^0.3.0",
     "i18next-sprintf-postprocessor": "^0.2.2",
+    "indexof": "0.0.1",
     "intro.js": "^2.3.0",
     "jquery": "^3.1.1",
     "jquery-i18next": "^1.1.0",


### PR DESCRIPTION
#### What does this PR do?

This PR fixes the bug that prevented checking out by requiring some `tour` properties.

#### Description of Task to be completed?

The task was to figure out a fix that would allow the registered and guest users checkout after they have added products to their cart.
#### How should this be manually tested?

Visit the site, if you are a guest or registered, after you have added products to your cart, checkout, add an address and then save. The address would be committed to memory which wasn't possible prior to the fix.

#### What are the relevant pivotal tracker stories?

[#134137969](https://www.pivotaltracker.com/story/show/134137969) Guest user should be able to checkout without the address error

#### Screenshots (if appropriate)
![screenshot from 2016-11-14 08 04 07](https://cloud.githubusercontent.com/assets/10448811/20255977/f7c76c74-aa40-11e6-8bd0-b9f5ffea02b0.png)

