### PR TITLE
#133002627 admin user should be able to cancel orders refactor additions

### DIFF
--- a/imports/plugins/core/orders/client/templates/list/ordersList.js
+++ b/imports/plugins/core/orders/client/templates/list/ordersList.js
@@ -65,7 +65,7 @@ Template.dashboardOrdersList.helpers({
         let alertText = "Are you sure you want to cancel this order";
 
         if (status === "shipped") {
-          alertText = `${alertText}, your order has been shipped and your
+          alertText = `${alertText}, your order has been shipped and
           your shipping charge will not be refunded!`;
         }
         Alerts.alert({

--- a/imports/plugins/core/orders/client/templates/list/ordersList.js
+++ b/imports/plugins/core/orders/client/templates/list/ordersList.js
@@ -53,7 +53,7 @@ Template.dashboardOrdersList.helpers({
   // Create a helper to import in the FlatButton react component for
   // cancelOrder button
   CancelOrderButton() {
-    const order = this;
+    const order = this || Template.instance().data;
     return  {
       component: FlatButton,
       kind: "flat",
@@ -61,11 +61,16 @@ Template.dashboardOrdersList.helpers({
       label: "Cancel order",
       disabled: Template.dashboardOrdersList.__helpers.get("getClassName").call(this, order),
       onClick() {
+        const status = order.workflow.status.split("/")[1];
+        let alertText = "Are you sure you want to cancel this order";
+
+        if (status === "shipped") {
+          alertText = `${alertText}, your order has been shipped and your
+          your shipping charge will not be refunded!`;
+        }
         Alerts.alert({
           title: "Cancel order",
-          text: `Are you sure you want to cancel this order,
-          your shipping charge would not be refunded if your
-          order has been shipped`,
+          text: alertText,
           showCancelButton: true,
           confirmButtonText: "Cancel Order"
         }, (isConfirm) => {

--- a/imports/plugins/core/orders/client/templates/workflow/shippingTracking.html
+++ b/imports/plugins/core/orders/client/templates/workflow/shippingTracking.html
@@ -48,6 +48,7 @@
             <option value="wrong-item">Wrong Item</option>
             <option value="damaged">Damaged in transit</option>
             <option value="out-of-stock">Item out of stock</option>
+            <option value="out-of-stock">Customer changed mind</option>
             <option value="others">Other reasons</option>
           </select>
         </div>


### PR DESCRIPTION
### What does this PR do?
Add `customer changed mind` as part of the reasons for cancelling an order. Also, modifies the cancel order alert from the customer's view to reflect if the order has been shipped or not. 

### Description of Task to be completed?
* Add `customer changed mind` to cancellation reasons
* Modify the cancel order message to show or hide some part of the message if the order has shipped or not.

### How should this be manually tested?
* Go to a non-completed order and check cancellation reasons, `customer changed mind` should appear there.
* Login as a buyer and make an order. Go to the user profile page to view the orders the user has made and click on the cancel order button, depending on the order status (shipped or otherwise) the message should be different. If order has been shipped the message should be `Are you sure you want to cancel this order, your order has been shipped and your shipping charge will not be refunded!`, while any other status apart from completed should show `Are you sure you want to cancel this order`.

### What are the relevant pivotal tracker stories?
#133002627 Admin user should be able to cancel orders

