### PR TITLE
#133002639 admin can manage static pages fixes

### DIFF
--- a/imports/plugins/core/ui-navbar/client/components/navbar/navbar.js
+++ b/imports/plugins/core/ui-navbar/client/components/navbar/navbar.js
@@ -5,12 +5,13 @@ import { Tags, Pages } from "/lib/collections";
 
 Template.CoreNavigationBar.onCreated(function () {
   this.state = new ReactiveDict();
-  this.subscribe("Pages");
   this.state.setDefault({
     pages: []
   });
-  Meteor.call("pages/getPages", (err, data) => {
-    this.state.set("pages", data);
+
+  this.autorun(() => {
+    this.subscribe("Pages");
+    this.state.set("pages", Pages.find().fetch());
   });
 });
 

--- a/imports/plugins/included/static-pages/client/templates/pages.js
+++ b/imports/plugins/included/static-pages/client/templates/pages.js
@@ -149,7 +149,7 @@ Template.pages.helpers({
     return "edit";
   },
   pageCreate() {
-    return "create"
+    return "create";
   }
 });
 

--- a/server/methods/core/pages.js
+++ b/server/methods/core/pages.js
@@ -59,7 +59,7 @@ Meteor.methods({
 
     const pageId = Pages.findOne({pageName: name})._id;
     Pages.remove(pageId);
-    Logger.info("Page updated");
+    Logger.info("Page deleted");
   },
   "pages/getPages": function () {
     return Pages.find().fetch();


### PR DESCRIPTION
### What does this PR do?
Fix issues that caused new pages not to show on the `other pages` menu drop down on the navbar.

### Description of Task to be completed?
* Add autorun to enable the Template listen for changes in the database

### How should this be manually tested?
As an admin create a new static page and check the `other pages` dropdown, the new page should appear

### What are the relevant pivotal tracker stories?
#133002639 Static Page Management - Admin can manage static pages