### PR TITLE
#135415303 fixes rates retrieval bug in paystack payments

### DIFF
--- a/private/data/Shops.json
+++ b/private/data/Shops.json
@@ -394,7 +394,7 @@
       "scale": 0
     }
   },
-  "currency": "NGN",
+  "currency": "USD",
   "languages": [{
     "label": "العربية",
     "i18n": "ar",
@@ -3073,7 +3073,7 @@
     "city": "Santa Monica",
     "region": "CA",
     "postal": "90401",
-    "country": "NG",
+    "country": "US",
     "phone": "8885551212",
     "isCommercial": true,
     "isShippingDefault": true,
@@ -3095,8 +3095,7 @@
     "tag",
     "index",
     "cart/checkout",
-    "cart/completed",
-    "wallet"
+    "cart/completed"
   ]
 }, {
   "_id": "ddzuN2YPvgvx7rJS5",
@@ -3490,7 +3489,7 @@
       "scale": 0
     }
   },
-  "currency": "NGN",
+  "currency": "USD",
   "languages": [{
     "label": "العربية",
     "i18n": "ar",
@@ -6191,7 +6190,6 @@
     "tag",
     "index",
     "cart/checkout",
-    "cart/completed",
-    "wallet"
+    "cart/completed"
   ]
 }]


### PR DESCRIPTION
#### What does this PR do?

This PR fixes the bug that hampered reaction commerce retrieving exchange rates.

#### Description of Task to be completed?

The task was to figure out a fix that would allow the server retrieve exchange rates from OpenExchangeRates.org
#### How should this be manually tested?

Visit the site, if you are a guest or registered, after you have added products to your cart, checkout, and pay with paysatck or topup your wallet with paystack.

#### What are the relevant pivotal tracker stories?
[#135415303](https://www.pivotaltracker.com/story/show/135415303) Rates should be retrievable via OpenExchangeRates

#### Screenshots (if appropriate)
![screenshot from 2016-12-02 15 14 41](https://cloud.githubusercontent.com/assets/10448811/20837095/ce21e0f0-b8a2-11e6-9b19-3c615fd57812.png)
